### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -162,7 +162,7 @@ jobs:
         run: docker build . --file Dockerfile --tag bilalcaliskan/metadata-scraper:${{ steps.previoustag.outputs.tag }}
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: bilalcaliskan/metadata-scraper
           tags: "latest,${{ steps.previoustag.outputs.tag }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore